### PR TITLE
PipeWire Support + Use debian slim

### DIFF
--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:stable-slim
 
 ARG BUILD_DATE
 ARG VCS_REF

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -19,6 +19,8 @@ RUN set -eux ; \
     apt-get install -y --no-install-recommends \
         mpd \
         mpc \
+        pipewire-audio wireplumber \
+        pipewire-media-session- \
     ; \
     rm -rf /var/lib/apt/lists/* ; \
     mkdir /var/lib/mpd/data ; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
     ports:
       - 6600:6600/tcp  # MPD Client
       - 8000:8000/tcp  # Stream
+    ## PipeWire support
+    #environment:
+      #- XDG_RUNTIME_DIR=/tmp
     volumes:
       - ./Music:/var/lib/mpd/music:ro
       - ./playlists:/var/lib/mpd/playlists:rw
@@ -19,6 +22,8 @@ services:
       ## Time:
       #- /etc/timezone:/etc/timezone:ro
       #- /etc/localtime:/etc/localtime:ro
+      ## PipeWire support by mounting the host socket
+      #- /run/user/1000/pipewire-0:/tmp/pipewire-0
     #devices:
     #  - "/dev/snd:/dev/snd"
     #cap_add:
@@ -28,7 +33,7 @@ services:
       interval: 60s
       timeout: 5s
       retries: 3
-  
+
 #  # https://github.com/jcorporation/myMPD
 #  mympd:
 #    image: ghcr.io/jcorporation/mympd/mympd:latest
@@ -40,7 +45,7 @@ services:
 #    environment:
 #      - TZ=Europe/Berlin
 #      - UMASK_SET=022 #optional
-#      # Notice: After the first start all environment variables are ignored, except loglevel. 
+#      # Notice: After the first start all environment variables are ignored, except loglevel.
 #      - MPD_HOST=mpd
 #      - MPD_PORT=6600
 #      #- MPD_TIMEOUT=30

--- a/mpd.conf
+++ b/mpd.conf
@@ -213,6 +213,12 @@ input {
 # blocks. Setting this block is optional, though the server will only attempt
 # autodetection for one sound card.
 #
+# An example of a PipeWire output:
+#
+#audio_output {
+#  type "pipewire"
+#  name "PipeWire Playback"
+#}
 # An example of an ALSA output:
 #
 #audio_output {


### PR DESCRIPTION
Hi, this PR targets the Debian image:

- Use `debian:stable-slim` to reduce the image size
- PipeWire support by installing the needed packages, exposing the socket, and modifying mpd.conf
- The user must have a PipeWire server configured on the host machine. The mpd container contains the PipeWire client-side libs they'll need. It'll be connected to the host via the PipeWire socket


